### PR TITLE
Refresh metronome UI with modern PWA styling

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,160 @@
 @import "tailwindcss";
 
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  --background: #050918;
+  --foreground: #f4f7ff;
+  --surface: rgba(17, 24, 39, 0.6);
+  --surface-strong: rgba(22, 30, 47, 0.85);
+  --border-soft: rgba(148, 163, 184, 0.25);
+  --primary: #7c5cff;
+  --primary-strong: #5b3bd6;
+  --accent: #5eead4;
+  --muted: #9aa7d9;
+  --glow: rgba(94, 234, 212, 0.55);
+  --shadow-strong: rgba(5, 8, 24, 0.65);
+  --gradient-background:
+    radial-gradient(
+      120% 120% at 50% 0%,
+      rgba(124, 92, 255, 0.24) 0%,
+      rgba(8, 11, 27, 0) 60%
+    ),
+    radial-gradient(
+      90% 90% at 10% 90%,
+      rgba(94, 234, 212, 0.18) 0%,
+      rgba(5, 9, 24, 0) 70%
+    ), #050918;
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --font-sans: var(--font-body);
+  --font-display: var(--font-display);
 }
 
 body {
-  background: var(--background);
+  min-height: 100vh;
+  background: var(--gradient-background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family:
+    var(--font-body), "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    sans-serif;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.font-display {
+  font-family:
+    var(--font-display), var(--font-body), "Inter", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  letter-spacing: -0.04em;
+}
+
+.tempo-slider {
+  appearance: none;
+  width: 100%;
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: transparent;
+}
+
+.tempo-slider:focus-visible {
+  outline: 2px solid rgba(94, 234, 212, 0.7);
+  outline-offset: 6px;
+}
+
+.tempo-slider::-webkit-slider-runnable-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    rgba(124, 92, 255, 0.4),
+    rgba(94, 234, 212, 0.55)
+  );
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.tempo-slider::-moz-range-track {
+  height: 0.5rem;
+  border-radius: 9999px;
+  background: linear-gradient(
+    90deg,
+    rgba(124, 92, 255, 0.4),
+    rgba(94, 234, 212, 0.55)
+  );
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.tempo-slider::-webkit-slider-thumb {
+  appearance: none;
+  height: 1.25rem;
+  width: 1.25rem;
+  margin-top: -0.375rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7c5cff, #5eead4);
+  border: 2px solid rgba(12, 19, 43, 0.9);
+  box-shadow:
+    0 18px 35px rgba(94, 234, 212, 0.35),
+    0 0 0 1px rgba(124, 92, 255, 0.4);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+}
+
+.tempo-slider::-moz-range-thumb {
+  appearance: none;
+  height: 1.25rem;
+  width: 1.25rem;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #7c5cff, #5eead4);
+  border: 2px solid rgba(12, 19, 43, 0.9);
+  box-shadow:
+    0 18px 35px rgba(94, 234, 212, 0.35),
+    0 0 0 1px rgba(124, 92, 255, 0.4);
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+}
+
+.tempo-slider:active::-webkit-slider-thumb,
+.tempo-slider:active::-moz-range-thumb {
+  transform: scale(0.94);
+  box-shadow:
+    0 12px 22px rgba(94, 234, 212, 0.45),
+    0 0 0 1px rgba(124, 92, 255, 0.5);
+}
+
+.tempo-input {
+  appearance: textfield;
+  width: 100%;
+  border-radius: 9999px;
+  border: 1px solid var(--border-soft);
+  background: var(--surface);
+  color: var(--foreground);
+  font-family:
+    var(--font-display), var(--font-body), "Inter", -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1.25rem;
+  font-weight: 600;
+  text-align: center;
+  padding: 0.65rem 1.25rem;
+  transition:
+    border-color 0.2s ease,
+    box-shadow 0.2s ease,
+    background-color 0.2s ease;
+}
+
+.tempo-input:focus {
+  outline: none;
+  border-color: rgba(94, 234, 212, 0.7);
+  box-shadow: 0 0 0 6px rgba(94, 234, 212, 0.15);
+  background: var(--surface-strong);
+}
+
+.tempo-input::-webkit-inner-spin-button,
+.tempo-input::-webkit-outer-spin-button {
+  appearance: none;
+  margin: 0;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,14 +1,16 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import { Inter, Space_Grotesk } from 'next/font/google';
 import './globals.css';
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
+const inter = Inter({
+  variable: '--font-body',
+  display: 'swap',
   subsets: ['latin'],
 });
 
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
+const spaceGrotesk = Space_Grotesk({
+  variable: '--font-display',
+  display: 'swap',
   subsets: ['latin'],
 });
 
@@ -25,7 +27,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <head>
-        <meta name="theme-color" content="#111111" />
+        <meta name="theme-color" content="#050918" />
         <link rel="manifest" href="/manifest.webmanifest" />
         <meta name="apple-mobile-web-app-capable" content="yes" />
         <meta
@@ -34,7 +36,7 @@ export default function RootLayout({
         />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${spaceGrotesk.variable} antialiased`}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -33,8 +33,12 @@ export default function MetronomeClient() {
     return () => window.removeEventListener('keydown', handler);
   }, [bpm, isRunning, setBpm, start, stop]);
 
-  const status =
-    bpm === 0 || !isRunning ? 'Paused' : `${Math.max(currentBeat, 0) + 1}`;
+  const beatLabel =
+    bpm === 0 || !isRunning ? 'Paused' : `Beat ${Math.max(currentBeat, 0) + 1}`;
+
+  const buttonStateClasses = isRunning
+    ? 'from-[#5eead4] via-[#34d399] to-[#2dd4bf] text-slate-950 shadow-[0_28px_65px_rgba(45,212,191,0.35)] hover:shadow-[0_34px_75px_rgba(45,212,191,0.42)]'
+    : 'from-[#7c5cff] via-[#7c5cff] to-[#5eead4] text-white shadow-[0_34px_85px_rgba(124,92,255,0.5)] hover:shadow-[0_40px_95px_rgba(124,92,255,0.6)]';
 
   const onInstall = () => {
     installEvent?.prompt();
@@ -42,60 +46,155 @@ export default function MetronomeClient() {
   };
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-black p-4 px-12 text-white">
-      {/* Beat number */}
-      <div
-        className={`${status === 'Paused' ? 'text-lg' : 'text-7xl '}`}
-        aria-live="polite"
-      >
-        {status}
+    <main className="relative flex min-h-screen flex-col overflow-hidden text-white">
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute left-1/2 top-[-18%] h-80 w-80 -translate-x-1/2 rounded-full blur-3xl"
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(124, 92, 255, 0.35) 0%, rgba(124, 92, 255, 0) 70%)',
+          }}
+        />
+        <div
+          className="absolute bottom-[-20%] right-[-10%] h-80 w-80 rounded-full blur-3xl"
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(94, 234, 212, 0.28) 0%, rgba(94, 234, 212, 0) 70%)',
+          }}
+        />
+        <div
+          className="absolute left-[-20%] top-[35%] h-72 w-72 rounded-full blur-3xl"
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(79, 70, 229, 0.22) 0%, rgba(79, 70, 229, 0) 70%)',
+          }}
+        />
       </div>
 
-      {/* Beat Dots*/}
-      <div className="flex gap-2">
-        {[0, 1, 2].map((b) => (
-          <span
-            key={b}
-            className={`h-4 w-4 rounded-full ${currentBeat === b ? (b === 0 ? 'bg-red-500' : 'bg-white') : 'bg-gray-600'}`}
-          />
-        ))}
-      </div>
-      <button
-        type="button"
-        className="rounded bg-red-600 px-6 py-4 text-lg font-bold"
-        aria-label={isRunning ? 'Stop' : 'Start'}
-        onClick={isRunning ? stop : start}
-      >
-        {isRunning ? 'Stop' : 'Start'}
-      </button>
-      <label className="flex items-center gap-2">
-        <span>BPM {bpm}</span>
-        <input
-          type="number"
-          min={0}
-          max={400}
-          value={bpm}
-          onChange={(e) => setBpm(parseInt(e.target.value || '0', 10))}
-          className="w-20 rounded border p-1 text-black"
-        />
-      </label>
-      <input
-        type="range"
-        min={0}
-        max={400}
-        value={bpm}
-        onChange={(e) => setBpm(parseInt(e.target.value, 10))}
-        className="w-full max-w-sm"
-      />
-      {installEvent && (
-        <button
-          type="button"
-          className="rounded bg-blue-600 px-4 py-2"
-          onClick={onInstall}
-        >
-          Install
-        </button>
-      )}
+      <header className="z-10 flex w-full justify-center px-6 pt-6">
+        <div className="flex w-full max-w-md items-center justify-between rounded-3xl border border-white/10 bg-white/10 px-5 py-4 shadow-[0_20px_55px_rgba(5,8,24,0.55)] backdrop-blur-xl">
+          <div className="flex items-center gap-3 text-left">
+            <span
+              aria-hidden="true"
+              className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-[#7c5cff] via-[#6a5cff] to-[#5eead4] text-xl font-semibold text-white shadow-[0_0_30px_rgba(124,92,255,0.55)]"
+            >
+              ♫
+            </span>
+            <div className="flex flex-col leading-tight">
+              <span className="text-xs font-semibold uppercase tracking-[0.4em] text-slate-200/80">
+                Pulse
+              </span>
+              <span className="font-display text-lg font-semibold text-white">
+                Pulse Metronome
+              </span>
+            </div>
+          </div>
+          {installEvent && (
+            <button
+              type="button"
+              className="rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-100 transition-colors duration-200 hover:border-white/60 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5eead4]"
+              onClick={onInstall}
+            >
+              Install
+            </button>
+          )}
+        </div>
+      </header>
+
+      <section className="z-10 flex flex-1 items-center justify-center px-6 pb-12 pt-4">
+        <div className="flex w-full max-w-md flex-col items-center gap-8 rounded-[2.5rem] border border-white/10 bg-white/[0.05] px-6 py-9 text-center shadow-[0_40px_95px_rgba(5,8,24,0.7)] backdrop-blur-2xl sm:px-10 sm:py-12">
+          <div className="flex flex-col items-center gap-4">
+            <span
+              className="rounded-full border border-white/20 bg-white/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em] text-slate-200"
+              aria-live="polite"
+            >
+              {beatLabel}
+            </span>
+            <div className="flex items-baseline gap-2">
+              <span className="font-display text-6xl font-semibold tracking-tight text-white sm:text-7xl">
+                {bpm}
+              </span>
+              <span className="text-sm font-semibold uppercase tracking-[0.35em] text-slate-300">
+                bpm
+              </span>
+            </div>
+            <p className="max-w-[18rem] text-sm text-slate-400">
+              {isRunning && bpm > 0
+                ? 'Smooth visual pulses help you stay locked to the beat.'
+                : 'Dial in your tempo, then tap start for a pocket-perfect groove.'}
+            </p>
+          </div>
+
+          <div className="flex items-center justify-center gap-3">
+            {[0, 1, 2].map((beat) => {
+              const isActive = bpm > 0 && isRunning && currentBeat === beat;
+              const isDownbeat = beat === 0;
+
+              return (
+                <span
+                  key={beat}
+                  aria-hidden="true"
+                  className={`h-3 w-12 rounded-full transition-all duration-300 ease-out ${
+                    isActive
+                      ? isDownbeat
+                        ? 'scale-110 bg-gradient-to-r from-[#7c5cff] via-[#6b5cff] to-[#5eead4] shadow-[0_0_40px_rgba(124,92,255,0.6)]'
+                        : 'scale-105 bg-gradient-to-r from-[#5eead4] via-[#34d399] to-[#22d3ee] shadow-[0_0_38px_rgba(94,234,212,0.55)]'
+                      : 'scale-90 bg-white/15 opacity-60'
+                  }`}
+                />
+              );
+            })}
+          </div>
+
+          <button
+            type="button"
+            aria-label={isRunning ? 'Stop metronome' : 'Start metronome'}
+            aria-pressed={isRunning}
+            onClick={isRunning ? stop : start}
+            className={`group relative flex w-full max-w-xs items-center justify-center gap-2 rounded-full bg-gradient-to-r px-10 py-4 text-sm font-semibold uppercase tracking-[0.35em] transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#5eead4] active:translate-y-[1px] ${buttonStateClasses}`}
+          >
+            <span className="text-base font-semibold tracking-[0.3em]">
+              {isRunning ? 'Stop' : 'Start'}
+            </span>
+          </button>
+
+          <div className="flex w-full flex-col gap-6 text-left">
+            <label className="flex flex-col gap-3">
+              <span className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.4em] text-slate-300/90">
+                <span>Beats Per Minute</span>
+                <span className="font-display text-base tracking-tight text-white">
+                  {bpm}
+                </span>
+              </span>
+              <input
+                type="range"
+                min={0}
+                max={400}
+                value={bpm}
+                onChange={(e) => setBpm(parseInt(e.target.value, 10))}
+                className="tempo-slider"
+              />
+            </label>
+
+            <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-slate-300/80">
+              <span>Fine Tune</span>
+              <div className="flex items-center gap-3 rounded-full border border-white/10 bg-white/[0.05] px-4 py-3 transition focus-within:border-[#5eead4]/60 focus-within:bg-white/[0.08] focus-within:shadow-[0_0_35px_rgba(94,234,212,0.25)]">
+                <input
+                  type="number"
+                  min={0}
+                  max={400}
+                  value={bpm}
+                  onChange={(e) => setBpm(parseInt(e.target.value || '0', 10))}
+                  className="tempo-input"
+                />
+                <span className="text-sm font-medium tracking-normal text-slate-400">
+                  Type a precise tempo
+                </span>
+              </div>
+            </label>
+          </div>
+        </div>
+      </section>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- restyle the metronome page with a glassmorphism card, animated beat indicators, and an app header for PWA polish
- integrate Space Grotesk and Inter via next/font and apply a new neon-inspired palette with responsive typography
- update global styling for gradients, slider thumb/track, and numeric tempo input to match the refreshed theme

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c841372658832493588b03116ef912