### PR TITLE
Revamp metronome UI with premium glass aesthetic

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
   },
   "javascript": {
     "formatter": {
-      "quoteStyle": "single"
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "single"
     }
   },
   "linter": {
@@ -37,6 +38,11 @@
       "source": {
         "organizeImports": "on"
       }
+    }
+  },
+  "css": {
+    "formatter": {
+      "quoteStyle": "single"
     }
   }
 }

--- a/src/app/(pwa)/offline/page.tsx
+++ b/src/app/(pwa)/offline/page.tsx
@@ -1,6 +1,6 @@
 export default function OfflinePage() {
   return (
-    <main className="flex h-screen items-center justify-center bg-black text-white">
+    <main className='flex h-screen items-center justify-center bg-black text-white'>
       <p>You are offline</p>
     </main>
   );

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,160 +1,473 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
-  --background: #050918;
-  --foreground: #f4f7ff;
-  --surface: rgba(17, 24, 39, 0.6);
-  --surface-strong: rgba(22, 30, 47, 0.85);
-  --border-soft: rgba(148, 163, 184, 0.25);
-  --primary: #7c5cff;
-  --primary-strong: #5b3bd6;
-  --accent: #5eead4;
-  --muted: #9aa7d9;
-  --glow: rgba(94, 234, 212, 0.55);
-  --shadow-strong: rgba(5, 8, 24, 0.65);
-  --gradient-background:
-    radial-gradient(
-      120% 120% at 50% 0%,
-      rgba(124, 92, 255, 0.24) 0%,
-      rgba(8, 11, 27, 0) 60%
-    ),
-    radial-gradient(
-      90% 90% at 10% 90%,
-      rgba(94, 234, 212, 0.18) 0%,
-      rgba(5, 9, 24, 0) 70%
-    ), #050918;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-body);
-  --font-display: var(--font-display);
+  --bg-grad-from: #0e0b1f;
+  --bg-grad-to: #0a1f2a;
+  --accent: #7c5cff;
+  --accent-2: #35d0ba;
+  --text: #e9edf3;
+  --muted: #9aa7b2;
+  --panel: rgba(255, 255, 255, 0.06);
+  --panel-border: rgba(255, 255, 255, 0.12);
 }
 
 body {
-  min-height: 100vh;
-  background: var(--gradient-background);
-  color: var(--foreground);
-  font-family:
-    var(--font-body), "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
-    sans-serif;
   margin: 0;
+  min-height: 100vh;
+  background:
+    radial-gradient(
+      160% 160% at 15% -20%,
+      rgba(124, 92, 255, 0.35) 0%,
+      rgba(124, 92, 255, 0) 65%
+    ),
+    radial-gradient(
+      120% 120% at 110% 110%,
+      rgba(53, 208, 186, 0.25) 0%,
+      rgba(53, 208, 186, 0) 70%
+    ), linear-gradient(160deg, var(--bg-grad-from) 0%, var(--bg-grad-to) 100%);
+  color: var(--text);
+  font-family:
+    var(--font-sans), 'Space Grotesk', 'Poppins', 'Helvetica Neue', system-ui,
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   letter-spacing: -0.01em;
+  -webkit-font-smoothing: antialiased;
+  color-scheme: dark;
 }
 
-.font-display {
-  font-family:
-    var(--font-display), var(--font-body), "Inter", -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
+.app-shell {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 100vh;
+  padding: 1.75rem 1.25rem 2.25rem;
+  align-items: center;
+  justify-content: center;
+}
+
+.metronome-card {
+  position: relative;
+  width: min(100%, 26rem);
+  border-radius: 2rem;
+  background: var(--panel);
+  border: 1px solid var(--panel-border);
+  padding: 3.5rem 1.75rem 3rem;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.08),
+    0 45px 85px rgba(5, 8, 24, 0.72);
+  backdrop-filter: blur(26px);
+  color: var(--text);
+}
+
+@media (min-width: 640px) {
+  .metronome-card {
+    padding: 4rem 2.5rem 3.5rem;
+  }
+}
+
+.card-content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+  text-align: center;
+}
+
+.status-chip {
+  position: absolute;
+  top: 1.15rem;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 0.45rem 1.25rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: var(--text);
+  background: rgba(124, 92, 255, 0.18);
+  border: 1px solid rgba(124, 92, 255, 0.35);
+  box-shadow: 0 16px 35px rgba(5, 8, 24, 0.5);
+  backdrop-filter: blur(14px);
+  animation: chipFade 180ms ease-out;
+}
+
+.status-chip[data-state='playing'] {
+  background: rgba(53, 208, 186, 0.22);
+  border-color: rgba(53, 208, 186, 0.35);
+}
+
+.install-button {
+  position: absolute;
+  top: 1.25rem;
+  right: 1.25rem;
+  padding: 0.35rem 0.9rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.24em;
+  text-transform: uppercase;
+  transition:
+    border-color 150ms ease,
+    background-color 150ms ease,
+    box-shadow 150ms ease;
+}
+
+.install-button:hover {
+  border-color: rgba(255, 255, 255, 0.4);
+  background: rgba(255, 255, 255, 0.16);
+  box-shadow: 0 12px 28px rgba(5, 8, 24, 0.4);
+}
+
+.install-button:focus-visible {
+  outline: 3px solid rgba(53, 208, 186, 0.4);
+  outline-offset: 3px;
+}
+
+.tempo-display {
+  display: grid;
+  gap: 0.45rem;
+  place-items: center;
+}
+
+.tempo-label {
+  font-size: 0.75rem;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+  color: rgba(233, 237, 243, 0.72);
+}
+
+.tempo-value {
+  font-size: clamp(3.5rem, 18vw, 4.75rem);
+  font-weight: 600;
   letter-spacing: -0.04em;
+}
+
+.tempo-unit {
+  font-size: 0.75rem;
+  letter-spacing: 0.42em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.beat-section {
+  display: grid;
+  gap: 0.6rem;
+  place-items: center;
+}
+
+.beat-label {
+  font-size: 0.7rem;
+  letter-spacing: 0.28em;
+  text-transform: uppercase;
+  color: rgba(233, 237, 243, 0.64);
+}
+
+.beat-pips {
+  display: flex;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.beat-pip {
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.12);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.12);
+  transform: scale(0.92);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease,
+    opacity 160ms ease;
+  opacity: 0.6;
+}
+
+.beat-pip.is-active {
+  background: linear-gradient(140deg, var(--accent) 0%, var(--accent-2) 100%);
+  box-shadow:
+    0 0 26px rgba(124, 92, 255, 0.55),
+    0 12px 18px rgba(9, 14, 29, 0.6);
+  transform: scale(1.15);
+  opacity: 1;
+  animation: beatPulse 520ms ease-out infinite;
+}
+
+.beat-value {
+  font-size: 1.25rem;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: rgba(233, 237, 243, 0.75);
+}
+
+.start-stop-button {
+  width: 100%;
+  margin-top: 0.5rem;
+  padding: 1rem 2.5rem;
+  border: none;
+  border-radius: 9999px;
+  background: linear-gradient(130deg, var(--accent) 0%, var(--accent-2) 100%);
+  color: var(--text);
+  font-size: 0.95rem;
+  font-weight: 600;
+  letter-spacing: 0.34em;
+  text-transform: uppercase;
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 32px 60px rgba(6, 12, 28, 0.65);
+  transition:
+    transform 140ms ease,
+    filter 140ms ease,
+    box-shadow 140ms ease;
+  touch-action: manipulation;
+}
+
+.start-stop-button[data-state='playing'] {
+  background: linear-gradient(130deg, var(--accent-2) 0%, #4ee5d0 100%);
+}
+
+.start-stop-button:hover {
+  box-shadow: 0 36px 68px rgba(6, 12, 28, 0.7);
+}
+
+.start-stop-button:focus-visible {
+  outline: 3px solid rgba(53, 208, 186, 0.45);
+  outline-offset: 4px;
+}
+
+.start-stop-button:active {
+  transform: scale(0.97);
+  filter: brightness(1.05);
+}
+
+.controls-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 1.65rem;
+  text-align: left;
+  margin-top: 0.75rem;
+}
+
+.slider-control,
+.number-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.control-label {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  letter-spacing: 0.36em;
+  color: rgba(233, 237, 243, 0.7);
+}
+
+.control-label__value {
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  color: var(--text);
 }
 
 .tempo-slider {
   appearance: none;
   width: 100%;
-  height: 0.5rem;
+  height: 0.65rem;
   border-radius: 9999px;
-  background: transparent;
+  background: linear-gradient(
+    120deg,
+    rgba(124, 92, 255, 0.35),
+    rgba(53, 208, 186, 0.45)
+  );
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  outline: none;
+  transition: box-shadow 150ms ease;
 }
 
 .tempo-slider:focus-visible {
-  outline: 2px solid rgba(94, 234, 212, 0.7);
-  outline-offset: 6px;
-}
-
-.tempo-slider::-webkit-slider-runnable-track {
-  height: 0.5rem;
-  border-radius: 9999px;
-  background: linear-gradient(
-    90deg,
-    rgba(124, 92, 255, 0.4),
-    rgba(94, 234, 212, 0.55)
-  );
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
-}
-
-.tempo-slider::-moz-range-track {
-  height: 0.5rem;
-  border-radius: 9999px;
-  background: linear-gradient(
-    90deg,
-    rgba(124, 92, 255, 0.4),
-    rgba(94, 234, 212, 0.55)
-  );
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.28),
+    0 0 0 6px rgba(53, 208, 186, 0.26);
 }
 
 .tempo-slider::-webkit-slider-thumb {
   appearance: none;
-  height: 1.25rem;
-  width: 1.25rem;
-  margin-top: -0.375rem;
+  width: 1.35rem;
+  height: 1.35rem;
+  margin-top: -0.35rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, #7c5cff, #5eead4);
-  border: 2px solid rgba(12, 19, 43, 0.9);
+  background: linear-gradient(140deg, var(--accent) 0%, var(--accent-2) 100%);
+  border: 2px solid rgba(14, 20, 34, 0.9);
   box-shadow:
-    0 18px 35px rgba(94, 234, 212, 0.35),
-    0 0 0 1px rgba(124, 92, 255, 0.4);
+    0 18px 30px rgba(124, 92, 255, 0.35),
+    0 0 0 4px rgba(124, 92, 255, 0.2);
   transition:
-    transform 0.15s ease,
-    box-shadow 0.2s ease;
+    transform 140ms ease,
+    box-shadow 160ms ease;
 }
 
 .tempo-slider::-moz-range-thumb {
   appearance: none;
-  height: 1.25rem;
-  width: 1.25rem;
+  width: 1.35rem;
+  height: 1.35rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, #7c5cff, #5eead4);
-  border: 2px solid rgba(12, 19, 43, 0.9);
+  background: linear-gradient(140deg, var(--accent) 0%, var(--accent-2) 100%);
+  border: 2px solid rgba(14, 20, 34, 0.9);
   box-shadow:
-    0 18px 35px rgba(94, 234, 212, 0.35),
-    0 0 0 1px rgba(124, 92, 255, 0.4);
+    0 18px 30px rgba(124, 92, 255, 0.35),
+    0 0 0 4px rgba(124, 92, 255, 0.2);
   transition:
-    transform 0.15s ease,
-    box-shadow 0.2s ease;
+    transform 140ms ease,
+    box-shadow 160ms ease;
 }
 
 .tempo-slider:active::-webkit-slider-thumb,
 .tempo-slider:active::-moz-range-thumb {
   transform: scale(0.94);
   box-shadow:
-    0 12px 22px rgba(94, 234, 212, 0.45),
-    0 0 0 1px rgba(124, 92, 255, 0.5);
+    0 14px 22px rgba(124, 92, 255, 0.45),
+    0 0 0 6px rgba(53, 208, 186, 0.28);
+}
+
+.number-control .control-heading {
+  text-transform: uppercase;
+  font-size: 0.68rem;
+  letter-spacing: 0.36em;
+  color: rgba(233, 237, 243, 0.7);
+}
+
+.number-field {
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  border-radius: 9999px;
+  border: 1px solid var(--panel-border);
+  padding: 0.75rem 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  transition:
+    border-color 160ms ease,
+    background-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.number-field:focus-within {
+  border-color: rgba(53, 208, 186, 0.5);
+  background: rgba(255, 255, 255, 0.08);
+  box-shadow: 0 0 0 4px rgba(53, 208, 186, 0.22);
 }
 
 .tempo-input {
   appearance: textfield;
-  width: 100%;
-  border-radius: 9999px;
-  border: 1px solid var(--border-soft);
-  background: var(--surface);
-  color: var(--foreground);
-  font-family:
-    var(--font-display), var(--font-body), "Inter", -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
-  font-size: 1.25rem;
+  width: 5rem;
+  border: none;
+  background: transparent;
+  color: var(--text);
+  font-size: 1.4rem;
   font-weight: 600;
+  letter-spacing: -0.02em;
   text-align: center;
-  padding: 0.65rem 1.25rem;
-  transition:
-    border-color 0.2s ease,
-    box-shadow 0.2s ease,
-    background-color 0.2s ease;
+  padding: 0;
 }
 
 .tempo-input:focus {
   outline: none;
-  border-color: rgba(94, 234, 212, 0.7);
-  box-shadow: 0 0 0 6px rgba(94, 234, 212, 0.15);
-  background: var(--surface-strong);
+}
+
+.number-hint {
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
 }
 
 .tempo-input::-webkit-inner-spin-button,
 .tempo-input::-webkit-outer-spin-button {
   appearance: none;
   margin: 0;
+}
+
+.paused-overlay {
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: scale(0.96);
+  background: radial-gradient(
+    120% 120% at 50% 40%,
+    rgba(14, 11, 31, 0.45) 0%,
+    rgba(14, 11, 31, 0.7) 65%,
+    rgba(14, 11, 31, 0.85) 100%
+  );
+  transition:
+    opacity 120ms ease,
+    transform 120ms ease,
+    backdrop-filter 120ms ease;
+  backdrop-filter: blur(0px);
+}
+
+.paused-overlay--visible {
+  opacity: 1;
+  transform: scale(1);
+  backdrop-filter: blur(7px);
+}
+
+.paused-overlay__content {
+  display: grid;
+  gap: 0.35rem;
+  text-align: center;
+  color: var(--text);
+  text-transform: none;
+}
+
+.paused-overlay__icon {
+  font-size: 2.25rem;
+  filter: drop-shadow(0 12px 20px rgba(124, 92, 255, 0.5));
+}
+
+.paused-overlay__label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.32em;
+  text-transform: uppercase;
+}
+
+.paused-overlay__helper {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+@keyframes beatPulse {
+  0% {
+    transform: scale(1.05);
+    box-shadow: 0 0 18px rgba(124, 92, 255, 0.45);
+  }
+  50% {
+    transform: scale(1.18);
+    box-shadow: 0 0 36px rgba(53, 208, 186, 0.55);
+  }
+  100% {
+    transform: scale(1.05);
+    box-shadow: 0 0 18px rgba(124, 92, 255, 0.45);
+  }
+}
+
+@keyframes chipFade {
+  from {
+    opacity: 0;
+    transform: translate(-50%, -8px);
+  }
+  to {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,17 +1,11 @@
 import type { Metadata } from 'next';
-import { Inter, Space_Grotesk } from 'next/font/google';
+import { Space_Grotesk } from 'next/font/google';
 import './globals.css';
 
-const inter = Inter({
-  variable: '--font-body',
-  display: 'swap',
-  subsets: ['latin'],
-});
-
 const spaceGrotesk = Space_Grotesk({
-  variable: '--font-display',
-  display: 'swap',
   subsets: ['latin'],
+  variable: '--font-sans',
+  display: 'swap',
 });
 
 export const metadata: Metadata = {
@@ -25,21 +19,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang='en'>
       <head>
-        <meta name="theme-color" content="#050918" />
-        <link rel="manifest" href="/manifest.webmanifest" />
-        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name='theme-color' content='#050918' />
+        <link rel='manifest' href='/manifest.webmanifest' />
+        <meta name='apple-mobile-web-app-capable' content='yes' />
         <meta
-          name="apple-mobile-web-app-status-bar-style"
-          content="black-translucent"
+          name='apple-mobile-web-app-status-bar-style'
+          content='black-translucent'
         />
       </head>
-      <body
-        className={`${inter.variable} ${spaceGrotesk.variable} antialiased`}
-      >
-        {children}
-      </body>
+      <body className={`${spaceGrotesk.variable} antialiased`}>{children}</body>
     </html>
   );
 }


### PR DESCRIPTION
## Summary
- replace the header with a centered glass metronome card, status chip, and install pill over a dark purple→teal gradient background
- restyle metronome controls with a gradient start/stop pill, glowing slider, animated beat pips, and a clamped fine-tune input plus a subtle paused overlay
- load Space Grotesk through `next/font` and tune the formatter to keep single quotes across JS/JSX/CSS as required

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c85c911340832498caabddbf5359a6