### PR TITLE
Add time signature selector to metronome UI

### DIFF
--- a/src/app/components/TimeSignatureSelect.tsx
+++ b/src/app/components/TimeSignatureSelect.tsx
@@ -1,0 +1,53 @@
+import type { ChangeEvent } from 'react';
+
+type SignatureMap = typeof import('@/lib/useMetronome').SIGNATURES;
+type TimeSignatureKey = keyof SignatureMap;
+
+const TIME_SIGNATURE_OPTIONS: TimeSignatureKey[] = [
+  '2/4',
+  '3/4',
+  '4/4',
+  '6/8',
+  '9/8',
+  '12/8',
+];
+
+interface TimeSignatureSelectProps {
+  value: TimeSignatureKey;
+  onChange: (signature: TimeSignatureKey) => void;
+}
+
+export function TimeSignatureSelect({
+  value,
+  onChange,
+}: TimeSignatureSelectProps) {
+  const handleChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    onChange(event.target.value as TimeSignatureKey);
+  };
+
+  return (
+    <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-slate-300/80">
+      <span>Time signature</span>
+      <div className="relative flex items-center">
+        <select
+          aria-label="Time signature"
+          value={value}
+          onChange={handleChange}
+          className="w-full appearance-none rounded-full border border-white/10 bg-white/[0.08] px-4 py-3 pr-12 text-left text-sm font-medium tracking-[0.2em] text-white transition focus:border-[#5eead4]/60 focus:bg-white/[0.12] focus:outline-none focus:ring-2 focus:ring-[#5eead4]/40"
+        >
+          {TIME_SIGNATURE_OPTIONS.map((option) => (
+            <option key={option} value={option} className="text-slate-900">
+              {option}
+            </option>
+          ))}
+        </select>
+        <span
+          aria-hidden="true"
+          className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-slate-300/70"
+        >
+          ▾
+        </span>
+      </div>
+    </label>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,10 +2,20 @@
 
 import { useEffect, useState } from 'react';
 
+import { TimeSignatureSelect } from '@/app/components/TimeSignatureSelect';
 import { useMetronome } from '@/lib/useMetronome';
 
 export default function MetronomeClient() {
-  const { bpm, setBpm, start, stop, isRunning, currentBeat } = useMetronome();
+  const {
+    bpm,
+    setBpm,
+    start,
+    stop,
+    isRunning,
+    currentBeat,
+    timeSignature,
+    setTimeSignature,
+  } = useMetronome();
   const [installEvent, setInstallEvent] =
     useState<BeforeInstallPromptEvent | null>(null);
 
@@ -32,6 +42,17 @@ export default function MetronomeClient() {
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
   }, [bpm, isRunning, setBpm, start, stop]);
+
+  useEffect(() => {
+    const storedSignature = localStorage.getItem('timeSignatureKey');
+    if (storedSignature) {
+      setTimeSignature(storedSignature);
+    }
+  }, [setTimeSignature]);
+
+  useEffect(() => {
+    localStorage.setItem('timeSignatureKey', timeSignature);
+  }, [timeSignature]);
 
   const beatLabel =
     bpm === 0 || !isRunning ? 'Paused' : `${Math.max(currentBeat, 0) + 1}`;
@@ -192,6 +213,10 @@ export default function MetronomeClient() {
                 </span>
               </div>
             </label>
+            <TimeSignatureSelect
+              value={timeSignature}
+              onChange={(signature) => setTimeSignature(signature)}
+            />
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add a styled TimeSignatureSelect component for changing time signatures
- integrate the selector into the metronome page and connect it to the hook
- persist the selected signature in localStorage for reloads

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8957cad208324b6a30d6667780e35