### PR TITLE
feat: refresh palette with orange and teal theme

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -19,6 +19,11 @@
       "quoteStyle": "single"
     }
   },
+  "css": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
   "linter": {
     "enabled": true,
     "rules": {

--- a/src/app/components/TimeSignatureSelect.tsx
+++ b/src/app/components/TimeSignatureSelect.tsx
@@ -28,24 +28,24 @@ export function TimeSignatureSelect({
   };
 
   return (
-    <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-slate-300/80">
+    <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-[var(--text-muted)]">
       <span>Time signature</span>
       <div className="relative flex items-center">
         <select
           aria-label="Time signature"
           value={value}
           onChange={handleChange}
-          className="w-full appearance-none rounded-full border border-white/10 bg-white/[0.08] px-4 py-3 pr-12 text-left text-sm font-medium tracking-[0.2em] text-white transition focus:border-[#5eead4]/60 focus:bg-white/[0.12] focus:outline-none focus:ring-2 focus:ring-[#5eead4]/40"
+          className="w-full appearance-none rounded-full border border-[color:var(--accent-secondary-soft)] bg-[var(--surface)] px-4 py-3 pr-12 text-left text-sm font-medium tracking-[0.2em] text-[#f5f5f5] transition focus:border-[var(--accent-secondary)] focus:bg-[var(--surface-strong)] focus:outline-none focus:ring-2 focus:ring-[rgba(255,90,0,0.35)]"
         >
           {TIME_SIGNATURE_OPTIONS.map((option) => (
-            <option key={option} value={option} className="text-slate-900">
+            <option key={option} value={option} className="text-[#1a1a1a]">
               {option}
             </option>
           ))}
         </select>
         <span
           aria-hidden="true"
-          className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-slate-300/70"
+          className="pointer-events-none absolute right-4 top-1/2 -translate-y-1/2 text-sm text-[var(--text-muted)]"
         >
           ▾
         </span>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,33 +1,29 @@
-@import "tailwindcss";
+@import 'tailwindcss';
 
 :root {
-  --background: #050918;
-  --foreground: #f4f7ff;
-  --surface: rgba(17, 24, 39, 0.6);
-  --surface-strong: rgba(22, 30, 47, 0.85);
-  --border-soft: rgba(148, 163, 184, 0.25);
-  --primary: #7c5cff;
-  --primary-strong: #5b3bd6;
-  --accent: #5eead4;
-  --muted: #9aa7d9;
-  --glow: rgba(94, 234, 212, 0.55);
-  --shadow-strong: rgba(5, 8, 24, 0.65);
-  --gradient-background:
-    radial-gradient(
-      120% 120% at 50% 0%,
-      rgba(124, 92, 255, 0.24) 0%,
-      rgba(8, 11, 27, 0) 60%
-    ),
-    radial-gradient(
-      90% 90% at 10% 90%,
-      rgba(94, 234, 212, 0.18) 0%,
-      rgba(5, 9, 24, 0) 70%
-    ), #050918;
+  --bg-from: #2c2c2c;
+  --bg-to: #1a1a1a;
+  --accent-primary: #ff5a00;
+  --accent-secondary: #005f63;
+  --accent-secondary-strong: rgba(0, 95, 99, 0.7);
+  --accent-secondary-soft: rgba(0, 95, 99, 0.45);
+  --text: #f5f5f5;
+  --text-muted: #a0a0a0;
+  --surface: rgba(255, 255, 255, 0.06);
+  --surface-strong: rgba(255, 255, 255, 0.12);
+  --border-soft: rgba(160, 160, 160, 0.18);
+  --glow: 0 0 12px rgba(255, 90, 0, 0.65);
+  --shadow-strong: rgba(0, 0, 0, 0.65);
+  --gradient-background: linear-gradient(
+    to bottom,
+    var(--bg-from),
+    var(--bg-to)
+  );
 }
 
 @theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
+  --color-background: var(--bg-to);
+  --color-foreground: var(--text);
   --font-sans: var(--font-body);
   --font-display: var(--font-display);
 }
@@ -35,9 +31,9 @@
 body {
   min-height: 100vh;
   background: var(--gradient-background);
-  color: var(--foreground);
+  color: var(--text);
   font-family:
-    var(--font-body), "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    var(--font-body), 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI',
     sans-serif;
   margin: 0;
   letter-spacing: -0.01em;
@@ -45,8 +41,8 @@ body {
 
 .font-display {
   font-family:
-    var(--font-display), var(--font-body), "Inter", -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
+    var(--font-display), var(--font-body), 'Inter', -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
   letter-spacing: -0.04em;
 }
 
@@ -59,7 +55,7 @@ body {
 }
 
 .tempo-slider:focus-visible {
-  outline: 2px solid rgba(94, 234, 212, 0.7);
+  outline: 2px solid rgba(255, 90, 0, 0.65);
   outline-offset: 6px;
 }
 
@@ -68,11 +64,11 @@ body {
   border-radius: 9999px;
   background: linear-gradient(
     90deg,
-    rgba(124, 92, 255, 0.4),
-    rgba(94, 234, 212, 0.55)
+    var(--accent-secondary-strong),
+    rgba(255, 90, 0, 0.45)
   );
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(245, 245, 245, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.4);
 }
 
 .tempo-slider::-moz-range-track {
@@ -80,11 +76,11 @@ body {
   border-radius: 9999px;
   background: linear-gradient(
     90deg,
-    rgba(124, 92, 255, 0.4),
-    rgba(94, 234, 212, 0.55)
+    var(--accent-secondary-strong),
+    rgba(255, 90, 0, 0.45)
   );
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(245, 245, 245, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.4);
 }
 
 .tempo-slider::-webkit-slider-thumb {
@@ -93,11 +89,11 @@ body {
   width: 1.25rem;
   margin-top: -0.375rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, #7c5cff, #5eead4);
-  border: 2px solid rgba(12, 19, 43, 0.9);
+  background: var(--accent-primary);
+  border: 2px solid rgba(0, 0, 0, 0.65);
   box-shadow:
-    0 18px 35px rgba(94, 234, 212, 0.35),
-    0 0 0 1px rgba(124, 92, 255, 0.4);
+    var(--glow),
+    0 0 0 1px rgba(255, 255, 255, 0.16);
   transition:
     transform 0.15s ease,
     box-shadow 0.2s ease;
@@ -108,11 +104,11 @@ body {
   height: 1.25rem;
   width: 1.25rem;
   border-radius: 50%;
-  background: linear-gradient(135deg, #7c5cff, #5eead4);
-  border: 2px solid rgba(12, 19, 43, 0.9);
+  background: var(--accent-primary);
+  border: 2px solid rgba(0, 0, 0, 0.65);
   box-shadow:
-    0 18px 35px rgba(94, 234, 212, 0.35),
-    0 0 0 1px rgba(124, 92, 255, 0.4);
+    var(--glow),
+    0 0 0 1px rgba(255, 255, 255, 0.16);
   transition:
     transform 0.15s ease,
     box-shadow 0.2s ease;
@@ -122,8 +118,8 @@ body {
 .tempo-slider:active::-moz-range-thumb {
   transform: scale(0.94);
   box-shadow:
-    0 12px 22px rgba(94, 234, 212, 0.45),
-    0 0 0 1px rgba(124, 92, 255, 0.5);
+    0 12px 22px rgba(255, 90, 0, 0.55),
+    0 0 0 1px rgba(255, 255, 255, 0.2);
 }
 
 .tempo-input {
@@ -132,10 +128,10 @@ body {
   border-radius: 9999px;
   border: 1px solid var(--border-soft);
   background: var(--surface);
-  color: var(--foreground);
+  color: var(--text);
   font-family:
-    var(--font-display), var(--font-body), "Inter", -apple-system,
-    BlinkMacSystemFont, "Segoe UI", sans-serif;
+    var(--font-display), var(--font-body), 'Inter', -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 1.25rem;
   font-weight: 600;
   text-align: center;
@@ -148,8 +144,8 @@ body {
 
 .tempo-input:focus {
   outline: none;
-  border-color: rgba(94, 234, 212, 0.7);
-  box-shadow: 0 0 0 6px rgba(94, 234, 212, 0.15);
+  border-color: var(--accent-secondary-strong);
+  box-shadow: 0 0 0 6px rgba(255, 90, 0, 0.12);
   background: var(--surface-strong);
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,214 +6,226 @@ import { TimeSignatureSelect } from '@/app/components/TimeSignatureSelect';
 import { useMetronome } from '@/lib/useMetronome';
 
 export default function MetronomeClient() {
-    const {
-        bpm,
-        setBpm,
-        start,
-        stop,
-        isRunning,
-        currentBeat,
-        timeSignature,
-        setTimeSignature,
-        pulsesInBar,
-    } = useMetronome();
-    const [installEvent, setInstallEvent] =
-        useState<BeforeInstallPromptEvent | null>(null);
-    const hasHydratedTimeSignature = useRef(false);
-    
-    useEffect(() => {
-        const handler = (e: BeforeInstallPromptEvent) => {
-            e.preventDefault();
-            setInstallEvent(e);
-        };
-        window.addEventListener('beforeinstallprompt', handler);
-        return () => window.removeEventListener('beforeinstallprompt', handler);
-    }, []);
-    
-    useEffect(() => {
-        const handler = (e: KeyboardEvent) => {
-            if (e.code === 'Space' || e.code === 'Enter') {
-                e.preventDefault();
-                isRunning ? stop() : start();
-            } else if (e.code === 'ArrowUp') {
-                setBpm(bpm + 1);
-            } else if (e.code === 'ArrowDown') {
-                setBpm(bpm - 1);
-            }
-        };
-        window.addEventListener('keydown', handler);
-        return () => window.removeEventListener('keydown', handler);
-    }, [bpm, isRunning, setBpm, start, stop]);
-    
-    useEffect(() => {
-        if (hasHydratedTimeSignature.current) {
-            localStorage.setItem('timeSignatureKey', timeSignature);
-        }
-    }, [timeSignature]);
-    
-    useEffect(() => {
-        if (hasHydratedTimeSignature.current) {
-            return;
-        }
-        
-        const storedSignature = localStorage.getItem('timeSignatureKey');
-        if (storedSignature && storedSignature !== timeSignature) {
-            setTimeSignature(storedSignature);
-        }
-        
-        hasHydratedTimeSignature.current = true;
-    }, [setTimeSignature, timeSignature]);
-    
-    const beatLabel =
-        bpm === 0 || !isRunning ? 'Paused' : `${Math.max(currentBeat, 0) + 1}`;
-    
-    const buttonStateClasses = isRunning
-        ? 'from-[#5eead4] via-[#34d399] to-[#2dd4bf] text-slate-950 shadow-[0_28px_65px_rgba(45,212,191,0.35)] hover:shadow-[0_34px_75px_rgba(45,212,191,0.42)]'
-        : 'from-[#7c5cff] via-[#7c5cff] to-[#5eead4] text-white shadow-[0_34px_85px_rgba(124,92,255,0.5)] hover:shadow-[0_40px_95px_rgba(124,92,255,0.6)]';
-    
-    const onInstall = () => {
-        installEvent?.prompt();
-        setInstallEvent(null);
+  const {
+    bpm,
+    setBpm,
+    start,
+    stop,
+    isRunning,
+    currentBeat,
+    timeSignature,
+    setTimeSignature,
+    pulsesInBar,
+  } = useMetronome();
+  const [installEvent, setInstallEvent] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const hasHydratedTimeSignature = useRef(false);
+
+  useEffect(() => {
+    const handler = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault();
+      setInstallEvent(e);
     };
-    
-    return (
-        <main className="relative flex min-h-screen flex-col overflow-hidden text-white">
-            <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
-                <div
-                    className="absolute left-1/2 top-[-18%] h-80 w-80 -translate-x-1/2 rounded-full blur-3xl"
-                    style={{
-                        background:
-                            'radial-gradient(circle at center, rgba(124, 92, 255, 0.35) 0%, rgba(124, 92, 255, 0) 70%)',
-                    }}
-                />
-                <div
-                    className="absolute bottom-[-20%] right-[-10%] h-80 w-80 rounded-full blur-3xl"
-                    style={{
-                        background:
-                            'radial-gradient(circle at center, rgba(94, 234, 212, 0.28) 0%, rgba(94, 234, 212, 0) 70%)',
-                    }}
-                />
-                <div
-                    className="absolute left-[-20%] top-[35%] h-72 w-72 rounded-full blur-3xl"
-                    style={{
-                        background:
-                            'radial-gradient(circle at center, rgba(79, 70, 229, 0.22) 0%, rgba(79, 70, 229, 0) 70%)',
-                    }}
-                />
-            </div>
-            
-            
-            {
-                installEvent && (
-                    <header className="z-10 flex w-full justify-center px-6 pt-6">
-                        <div className="flex w-full max-w-md items-center justify-between rounded-3xl border border-white/10 bg-white/10 px-5 py-4 shadow-[0_20px_55px_rgba(5,8,24,0.55)] backdrop-blur-xl">
-                            <button
-                                type="button"
-                                className="rounded-full border border-white/30 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-100 transition-colors duration-200 hover:border-white/60 hover:bg-white/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#5eead4]"
-                                onClick={onInstall}
-                            >
-                                Install
-                            </button>
-                        </div>
-                    </header>
-                )
-            }
-            <section className="z-10 flex items-center justify-center px-6 pb-12 pt-4">
-                <div className="flex w-full max-w-md flex-col items-center gap-8 rounded-[2.5rem] border border-white/10 bg-white/[0.05] px-6 py-9 text-center shadow-[0_40px_95px_rgba(5,8,24,0.7)] backdrop-blur-2xl sm:px-10 sm:py-12">
-                    <div className="flex flex-col items-center gap-4">
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.code === 'Space' || e.code === 'Enter') {
+        e.preventDefault();
+        isRunning ? stop() : start();
+      } else if (e.code === 'ArrowUp') {
+        setBpm(bpm + 1);
+      } else if (e.code === 'ArrowDown') {
+        setBpm(bpm - 1);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [bpm, isRunning, setBpm, start, stop]);
+
+  useEffect(() => {
+    if (hasHydratedTimeSignature.current) {
+      localStorage.setItem('timeSignatureKey', timeSignature);
+    }
+  }, [timeSignature]);
+
+  useEffect(() => {
+    if (hasHydratedTimeSignature.current) {
+      return;
+    }
+
+    const storedSignature = localStorage.getItem('timeSignatureKey');
+    if (storedSignature && storedSignature !== timeSignature) {
+      setTimeSignature(storedSignature);
+    }
+
+    hasHydratedTimeSignature.current = true;
+  }, [setTimeSignature, timeSignature]);
+
+  const beatLabel =
+    bpm === 0 || !isRunning ? 'Paused' : `${Math.max(currentBeat, 0) + 1}`;
+
+  const buttonStateClasses = isRunning
+    ? 'bg-[#c74a00] text-[#f5f5f5] shadow-[var(--glow)] hover:bg-[#ff6e1f] hover:shadow-[0_0_48px_rgba(255,90,0,0.7)]'
+    : 'bg-[var(--accent-primary)] text-[#f5f5f5] shadow-[var(--glow)] hover:bg-[#ff6e1f] hover:shadow-[0_0_48px_rgba(255,90,0,0.75)]';
+
+  const onInstall = () => {
+    installEvent?.prompt();
+    setInstallEvent(null);
+  };
+
+  return (
+    <main className="relative flex min-h-screen flex-col overflow-hidden text-[#f5f5f5]">
+      <div className="pointer-events-none absolute inset-0 -z-10 overflow-hidden">
+        <div
+          className="absolute left-1/2 top-[-18%] h-80 w-80 -translate-x-1/2 rounded-full blur-3xl"
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(255, 90, 0, 0.32) 0%, rgba(255, 90, 0, 0) 70%)',
+          }}
+        />
+        <div
+          className="absolute bottom-[-20%] right-[-10%] h-80 w-80 rounded-full blur-3xl"
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(0, 95, 99, 0.28) 0%, rgba(0, 95, 99, 0) 70%)',
+          }}
+        />
+        <div
+          className="absolute left-[-20%] top-[35%] h-72 w-72 rounded-full blur-3xl"
+          style={{
+            background:
+              'radial-gradient(circle at center, rgba(245, 245, 245, 0.12) 0%, rgba(245, 245, 245, 0) 70%)',
+          }}
+        />
+      </div>
+
+      {installEvent && (
+        <header className="z-10 flex w-full justify-center px-6 pt-6">
+          <div
+            className="flex w-full max-w-md items-center justify-between rounded-3xl border bg-[rgba(0,0,0,0.35)] px-5 py-4 shadow-[0_20px_55px_rgba(0,0,0,0.55)] backdrop-blur-xl"
+            style={{ borderColor: 'var(--accent-secondary-soft)' }}
+          >
+            <button
+              type="button"
+              className="rounded-full border bg-[rgba(255,255,255,0.08)] px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-[#f5f5f5] transition-colors duration-200 hover:border-[color:var(--accent-secondary)] hover:bg-[rgba(255,255,255,0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--accent-secondary)]"
+              style={{ borderColor: 'var(--accent-secondary-soft)' }}
+              onClick={onInstall}
+            >
+              Install
+            </button>
+          </div>
+        </header>
+      )}
+      <section className="z-10 flex flex-1 items-center justify-center px-6 pb-12 pt-4">
+        <div
+          className="flex w-full max-w-md flex-col items-center gap-8 rounded-[2.5rem] border bg-[rgba(0,0,0,0.45)] px-6 py-9 text-center shadow-[0_40px_95px_rgba(0,0,0,0.7)] backdrop-blur-2xl sm:px-10 sm:py-12"
+          style={{ borderColor: 'var(--accent-secondary-soft)' }}
+        >
+          <div className="flex flex-col items-center gap-4">
             <span
-                className="rounded-full border border-white/20 bg-white/10 px-4 py-1 text-7xl font-semibold uppercase tracking-[0.4em] text-slate-200"
-                aria-live="polite"
+              className="rounded-full border bg-[rgba(0,0,0,0.38)] px-4 py-1 text-7xl font-semibold uppercase tracking-[0.4em] text-[#f5f5f5]"
+              style={{ borderColor: 'var(--accent-secondary)' }}
+              aria-live="polite"
             >
               {beatLabel}
             </span>
-                        <div className="flex items-baseline gap-2">
-              <span className="font-display font-semibold text-white sm:text-7xl">
+            <div className="flex items-baseline gap-2">
+              <span className="font-display font-semibold text-[#f5f5f5] sm:text-7xl">
                 {bpm}
               </span>
-                            <span className="font-semibold uppercase tracking-[0.35em] text-slate-300">
+              <span className="font-semibold uppercase tracking-[0.35em] text-[var(--text-muted)]">
                 bpm
               </span>
-                        </div>
-                    </div>
-                    
-                    <div className="flex items-center justify-center gap-3">
-                        {Array.from(
-                            { length: Math.max(pulsesInBar, 1) },
-                            (_, beat) => beat,
-                        ).map((beat) => {
-                            const isActive = bpm > 0 && isRunning && currentBeat === beat;
-                            const isDownbeat = beat === 0;
-                            
-                            return (
-                                <span
-                                    key={beat}
-                                    aria-hidden="true"
-                                    className={`h-3 w-12 rounded-full transition-all duration-300 ease-out ${
-                                        isActive
-                                            ? isDownbeat
-                                                ? 'scale-110 bg-gradient-to-r from-[#7c5cff] via-[#6b5cff] to-[#5eead4] shadow-[0_0_40px_rgba(124,92,255,0.6)]'
-                                                : 'scale-105 bg-gradient-to-r from-[#5eead4] via-[#34d399] to-[#22d3ee] shadow-[0_0_38px_rgba(94,234,212,0.55)]'
-                                            : 'scale-90 bg-white/15 opacity-60'
-                                    }`}
-                                />
-                            );
-                        })}
-                    </div>
-                    
-                    <button
-                        type="button"
-                        aria-label={isRunning ? 'Stop metronome' : 'Start metronome'}
-                        aria-pressed={isRunning}
-                        onClick={isRunning ? stop : start}
-                        className={`group relative flex w-full max-w-xs items-center justify-center gap-2 rounded-full bg-gradient-to-r px-10 py-4 text-sm font-semibold uppercase tracking-[0.35em] transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[#5eead4] active:translate-y-[1px] ${buttonStateClasses}`}
-                    >
+            </div>
+          </div>
+
+          <div className="flex items-center justify-center gap-3">
+            {Array.from(
+              { length: Math.max(pulsesInBar, 1) },
+              (_, beat) => beat,
+            ).map((beat) => {
+              const isActive = bpm > 0 && isRunning && currentBeat === beat;
+              const isDownbeat = beat === 0;
+
+              return (
+                <span
+                  key={beat}
+                  aria-hidden="true"
+                  className={`h-3 w-12 rounded-full transition-all duration-300 ease-out ${
+                    isActive
+                      ? isDownbeat
+                        ? 'scale-110'
+                        : 'scale-105'
+                      : 'scale-90 opacity-70'
+                  }`}
+                  style={{
+                    backgroundColor: isActive
+                      ? isDownbeat
+                        ? 'var(--accent-primary)'
+                        : '#ff7833'
+                      : 'var(--accent-secondary)',
+                    boxShadow: isActive ? 'var(--glow)' : 'none',
+                  }}
+                />
+              );
+            })}
+          </div>
+
+          <button
+            type="button"
+            aria-label={isRunning ? 'Stop metronome' : 'Start metronome'}
+            aria-pressed={isRunning}
+            onClick={isRunning ? stop : start}
+            className={`group relative flex w-full max-w-xs items-center justify-center gap-2 rounded-full px-10 py-4 text-sm font-semibold uppercase tracking-[0.35em] transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent-secondary)] active:translate-y-[1px] active:shadow-[0_0_28px_rgba(255,90,0,0.55)] ${buttonStateClasses}`}
+          >
             <span className="text-base font-semibold tracking-[0.3em]">
               {isRunning ? 'Stop' : 'Start'}
             </span>
-                    </button>
-                    
-                    <div className="flex w-full flex-col gap-6 text-left">
-                        <label className="flex flex-col gap-3">
-              <span className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.4em] text-slate-300/90">
+          </button>
+
+          <div className="flex w-full flex-col gap-6 text-left">
+            <label className="flex flex-col gap-3">
+              <span className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.4em] text-[var(--text-muted)]">
                 <span>Beats Per Minute</span>
-                <span className="font-display text-base tracking-tight text-white">
+                <span className="font-display text-base tracking-tight text-[#f5f5f5]">
                   {bpm}
                 </span>
               </span>
-                            <input
-                                type="range"
-                                min={0}
-                                max={400}
-                                value={bpm}
-                                onChange={(e) => setBpm(parseInt(e.target.value, 10))}
-                                className="tempo-slider"
-                            />
-                        </label>
-                        
-                        {/*  */}
-                        <TimeSignatureSelect
-                            value={timeSignature}
-                            onChange={(signature) => setTimeSignature(signature)}
-                        />
-                    
-                    </div>
-                </div>
-            </section>
-        </main>
-    );
+              <input
+                type="range"
+                min={0}
+                max={400}
+                value={bpm}
+                onChange={(e) => setBpm(parseInt(e.target.value, 10))}
+                className="tempo-slider"
+              />
+            </label>
+
+            {/*  */}
+            <TimeSignatureSelect
+              value={timeSignature}
+              onChange={(signature) => setTimeSignature(signature)}
+            />
+          </div>
+        </div>
+      </section>
+    </main>
+  );
 }
 
 declare global {
-    interface BeforeInstallPromptEvent extends Event {
-        prompt: () => Promise<void>;
-        userChoice: Promise<{
-            outcome: 'accepted' | 'dismissed';
-            platform: string;
-        }>;
-    }
-    
-    interface WindowEventMap {
-        beforeinstallprompt: BeforeInstallPromptEvent;
-    }
+  interface BeforeInstallPromptEvent extends Event {
+    prompt: () => Promise<void>;
+    userChoice: Promise<{
+      outcome: 'accepted' | 'dismissed';
+      platform: string;
+    }>;
+  }
+
+  interface WindowEventMap {
+    beforeinstallprompt: BeforeInstallPromptEvent;
+  }
 }


### PR DESCRIPTION
## Summary
- define a dark gray gradient background and orange/teal accent tokens for the PWA
- restyle the metronome controls, beat indicators, and supporting text to use the new palette and glow
- refresh the time signature select styling and add CSS formatting preferences for single quotes

## Testing
- npm run lint
- npm run build *(fails: next/font cannot fetch Google Fonts in the sandboxed environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8a0f034348324989276f83e3adfa7