### PR TITLE
Translate UI text to Spanish

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,11 +4,11 @@ import withPWA from 'next-pwa';
 const config: NextConfig = {};
 
 export default withPWA({
-    dest: 'public',
-    disable: process.env.NODE_ENV === 'development',
-    register: true,
-    skipWaiting: true,
-    fallbacks: {
-        document: '/offline',
-    },
+  dest: 'public',
+  disable: process.env.NODE_ENV === 'development',
+  register: true,
+  skipWaiting: true,
+  fallbacks: {
+    document: '/offline',
+  },
 })(config);

--- a/src/app/(pwa)/offline/page.tsx
+++ b/src/app/(pwa)/offline/page.tsx
@@ -1,7 +1,9 @@
+import { OFFLINE_MESSAGE } from '@/lib/constants';
+
 export default function OfflinePage() {
   return (
     <main className="flex h-screen items-center justify-center bg-black text-white">
-      <p>You are offline</p>
+      <p>{OFFLINE_MESSAGE}</p>
     </main>
   );
 }

--- a/src/app/components/TimeSignatureSelect.tsx
+++ b/src/app/components/TimeSignatureSelect.tsx
@@ -2,6 +2,8 @@
 
 import type { ChangeEvent } from 'react';
 
+import { TIME_SIGNATURE_LABEL } from '@/lib/constants';
+
 type SignatureMap = typeof import('@/lib/useMetronome').SIGNATURES;
 type TimeSignatureKey = keyof SignatureMap;
 
@@ -29,10 +31,10 @@ export function TimeSignatureSelect({
 
   return (
     <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-[0.4em] text-[var(--text-muted)]">
-      <span>Time signature</span>
+      <span>{TIME_SIGNATURE_LABEL}</span>
       <div className="relative flex items-center">
         <select
-          aria-label="Time signature"
+          aria-label={TIME_SIGNATURE_LABEL}
           value={value}
           onChange={handleChange}
           className="w-full appearance-none rounded-full border border-[color:var(--accent-secondary-soft)] bg-[var(--surface)] px-4 py-3 pr-12 text-left text-sm font-medium tracking-[0.2em] text-[#f5f5f5] transition focus:border-[var(--accent-secondary)] focus:bg-[var(--surface-strong)] focus:outline-none focus:ring-2 focus:ring-[rgba(255,90,0,0.35)]"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from 'next';
 import { Inter, Space_Grotesk } from 'next/font/google';
+
+import { APP_DESCRIPTION, APP_TITLE, HTML_LANGUAGE } from '@/lib/constants';
+
 import './globals.css';
 
 const inter = Inter({
@@ -15,8 +18,8 @@ const spaceGrotesk = Space_Grotesk({
 });
 
 export const metadata: Metadata = {
-  title: 'Metronome',
-  description: 'Simple PWA metronome',
+  title: APP_TITLE,
+  description: APP_DESCRIPTION,
 };
 
 export default function RootLayout({
@@ -25,7 +28,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang={HTML_LANGUAGE}>
       <head>
         <meta name="theme-color" content="#050918" />
         <link rel="manifest" href="/manifest.webmanifest" />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,17 @@
 import { useEffect, useRef, useState } from 'react';
 
 import { TimeSignatureSelect } from '@/app/components/TimeSignatureSelect';
+import {
+  BPM_LABEL,
+  BPM_UNIT,
+  INSTALL_BUTTON_LABEL,
+  METRONOME_BEAT_LABEL,
+  METRONOME_START_ARIA_LABEL,
+  METRONOME_START_LABEL,
+  METRONOME_STATUS_PAUSED,
+  METRONOME_STOP_ARIA_LABEL,
+  METRONOME_STOP_LABEL,
+} from '@/lib/constants';
 import { useMetronome } from '@/lib/useMetronome';
 
 export default function MetronomeClient() {
@@ -26,12 +37,17 @@ export default function MetronomeClient() {
   const getBeatAriaLabel = (
     metronomeStatus: MetronomeStatus,
     display: string,
-  ): string => (metronomeStatus === 'paused' ? 'Paused' : `Beat ${display}`);
+  ): string =>
+    metronomeStatus === 'paused'
+      ? METRONOME_STATUS_PAUSED
+      : `${METRONOME_BEAT_LABEL} ${display}`;
 
   const status: MetronomeStatus =
     bpm === 0 || !isRunning ? 'paused' : 'running';
   const beatDisplay: string =
-    status === 'paused' ? 'Paused' : String(Math.max(currentBeat, 0) + 1);
+    status === 'paused'
+      ? METRONOME_STATUS_PAUSED
+      : String(Math.max(currentBeat, 0) + 1);
   const labelSize = status === 'paused' ? 'text-4xl' : 'text-7xl';
   const labelTone =
     status === 'paused'
@@ -128,7 +144,7 @@ export default function MetronomeClient() {
               style={{ borderColor: 'var(--accent-secondary-soft)' }}
               onClick={onInstall}
             >
-              Install
+              {INSTALL_BUTTON_LABEL}
             </button>
           </div>
         </header>
@@ -153,7 +169,7 @@ export default function MetronomeClient() {
                 {bpm}
               </span>
               <span className="font-semibold uppercase tracking-[0.35em] text-[var(--text-muted)]">
-                bpm
+                {BPM_UNIT}
               </span>
             </div>
           </div>
@@ -192,20 +208,22 @@ export default function MetronomeClient() {
 
           <button
             type="button"
-            aria-label={isRunning ? 'Stop metronome' : 'Start metronome'}
+            aria-label={
+              isRunning ? METRONOME_STOP_ARIA_LABEL : METRONOME_START_ARIA_LABEL
+            }
             aria-pressed={isRunning}
             onClick={isRunning ? stop : start}
             className={`group relative flex w-full max-w-xs items-center justify-center gap-2 rounded-full px-10 py-4 text-sm font-semibold uppercase tracking-[0.35em] transition-all duration-200 ease-out focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--accent-secondary)] active:translate-y-[1px] active:shadow-[0_0_28px_rgba(255,90,0,0.55)] ${buttonStateClasses}`}
           >
             <span className="text-base font-semibold tracking-[0.3em]">
-              {isRunning ? 'Stop' : 'Start'}
+              {isRunning ? METRONOME_STOP_LABEL : METRONOME_START_LABEL}
             </span>
           </button>
 
           <div className="flex w-full flex-col gap-6 text-left">
             <label className="flex flex-col gap-3">
               <span className="flex items-center justify-between text-xs font-semibold uppercase tracking-[0.4em] text-[var(--text-muted)]">
-                <span>Beats Per Minute</span>
+                <span>{BPM_LABEL}</span>
                 <span className="font-display text-base tracking-tight text-[#f5f5f5]">
                   {bpm}
                 </span>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,15 @@
+export const HTML_LANGUAGE = 'es';
+export const APP_TITLE = 'Metrónomo';
+export const APP_DESCRIPTION = 'Metrónomo PWA simple';
+
+export const INSTALL_BUTTON_LABEL = 'Instalar';
+export const METRONOME_STATUS_PAUSED = 'En pausa';
+export const METRONOME_BEAT_LABEL = 'Pulso';
+export const METRONOME_START_LABEL = 'Iniciar';
+export const METRONOME_STOP_LABEL = 'Detener';
+export const METRONOME_START_ARIA_LABEL = 'Iniciar metrónomo';
+export const METRONOME_STOP_ARIA_LABEL = 'Detener metrónomo';
+export const BPM_LABEL = 'Pulsos por minuto';
+export const BPM_UNIT = 'ppm';
+export const TIME_SIGNATURE_LABEL = 'Compás';
+export const OFFLINE_MESSAGE = 'Estás sin conexión';


### PR DESCRIPTION
## Summary
- add a constants module with the Spanish UI strings and metadata values
- switch the app layout, metronome screen, time signature selector, and offline page to use the shared constants

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c8aa699ca08324b91bd3b4488dbc52