### PR TITLE
Add selectable sound options to metronome

### DIFF
--- a/src/app/components/SoundSelect.tsx
+++ b/src/app/components/SoundSelect.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+const OPTIONS = [
+  { key: 'click', label: 'Click' },
+  { key: 'wood', label: 'Wood' },
+  { key: 'hihat', label: 'Hi-hat' },
+] as const;
+
+type SoundKey = (typeof OPTIONS)[number]['key'];
+
+interface Props {
+  value: SoundKey;
+  onChange: (k: SoundKey) => void;
+}
+
+export function SoundSelect({ value, onChange }: Props) {
+  return (
+    <div className="w-full mt-2">
+      <p className="block mb-2 text-xs font-semibold uppercase tracking-[0.35em] text-[var(--text-muted)]">
+        Sound
+      </p>
+      <div className="grid grid-cols-3 gap-2">
+        {OPTIONS.map((o) => {
+          const selected = value === o.key;
+          return (
+            <button
+              key={o.key}
+              type="button"
+              aria-label={`Sound ${o.label}`}
+              aria-pressed={selected}
+              onClick={() => onChange(o.key)}
+              className={`rounded-full px-3 py-3 text-sm transition-all
+                border
+                ${
+                  selected
+                    ? 'bg-[var(--accent-primary)] text-[#0b0b0b] shadow-[var(--glow)] border-transparent'
+                    : 'bg-[rgba(255,255,255,0.06)] text-[#f5f5f5] border-[color:var(--accent-secondary-soft)] hover:border-[color:var(--accent-secondary)]'
+                }`}
+            >
+              {o.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 
+import { SoundSelect } from '@/app/components/SoundSelect';
 import { TimeSignatureSelect } from '@/app/components/TimeSignatureSelect';
 import {
   BPM_LABEL,
@@ -27,6 +28,8 @@ export default function MetronomeClient() {
     timeSignature,
     setTimeSignature,
     pulsesInBar,
+    soundKind,
+    setSoundKind,
   } = useMetronome();
   const [installEvent, setInstallEvent] =
     useState<BeforeInstallPromptEvent | null>(null);
@@ -297,6 +300,7 @@ export default function MetronomeClient() {
               value={timeSignature}
               onChange={(signature) => setTimeSignature(signature)}
             />
+            <SoundSelect value={soundKind} onChange={setSoundKind} />
           </div>
         </div>
       </section>

--- a/src/lib/audio.ts
+++ b/src/lib/audio.ts
@@ -1,19 +1,104 @@
-export function scheduleClick(
+import type { SoundKind } from './useMetronome';
+
+type TickPlayer = (soundKind: SoundKind, accent: boolean, when: number) => void;
+
+export function createPlayTick(ctx: AudioContext): TickPlayer {
+  const destination = ctx.destination;
+
+  return (soundKind, accent, when) => {
+    switch (soundKind) {
+      case 'wood':
+        playWood(ctx, destination, accent, when);
+        break;
+      case 'hihat':
+        playHiHat(ctx, destination, accent, when);
+        break;
+      default:
+        playClick(ctx, destination, accent, when);
+        break;
+    }
+
+    if (accent && 'vibrate' in navigator) {
+      const delay = Math.max(when - ctx.currentTime, 0);
+      window.setTimeout(() => navigator.vibrate([30, 10, 10]), delay * 1000);
+    }
+  };
+}
+
+function playClick(
   ctx: AudioContext,
-  time: number,
+  destination: AudioNode,
   accent: boolean,
+  when: number,
 ) {
   const osc = ctx.createOscillator();
+  osc.type = 'square';
+  osc.frequency.setValueAtTime(accent ? 2200 : 1800, when);
+
   const gain = ctx.createGain();
+  const peak = accent ? 1 : 0.6;
+  gain.gain.setValueAtTime(peak, when);
+  gain.gain.exponentialRampToValueAtTime(0.0001, when + 0.03);
+
   osc.connect(gain);
-  gain.connect(ctx.destination);
-  osc.frequency.value = accent ? 2000 : 1000;
-  gain.gain.value = accent ? 1 : 0.5;
-  const duration = accent ? 0.03 : 0.02;
-  osc.start(time);
-  osc.stop(time + duration);
-  if (accent && 'vibrate' in navigator) {
-    const delay = Math.max(time - ctx.currentTime, 0);
-    window.setTimeout(() => navigator.vibrate([30, 10, 10]), delay * 1000);
+  gain.connect(destination);
+
+  osc.start(when);
+  osc.stop(when + 0.05);
+}
+
+function playWood(
+  ctx: AudioContext,
+  destination: AudioNode,
+  accent: boolean,
+  when: number,
+) {
+  const osc = ctx.createOscillator();
+  osc.type = 'sine';
+  osc.frequency.setValueAtTime(accent ? 880 : 820, when);
+
+  const gain = ctx.createGain();
+  const peak = accent ? 0.8 : 0.5;
+  gain.gain.setValueAtTime(peak, when);
+  gain.gain.exponentialRampToValueAtTime(0.0001, when + 0.055);
+
+  osc.connect(gain);
+  gain.connect(destination);
+
+  osc.start(when);
+  osc.stop(when + 0.08);
+}
+
+function playHiHat(
+  ctx: AudioContext,
+  destination: AudioNode,
+  accent: boolean,
+  when: number,
+) {
+  const length = Math.max(1, Math.floor(ctx.sampleRate * 0.02));
+  const buffer = ctx.createBuffer(1, length, ctx.sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < length; i += 1) {
+    const decay = 1 - i / length;
+    data[i] = (Math.random() * 2 - 1) * decay;
   }
+
+  const noise = ctx.createBufferSource();
+  noise.buffer = buffer;
+
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'highpass';
+  filter.frequency.setValueAtTime(8000, when);
+
+  const gain = ctx.createGain();
+  const peak = accent ? 0.7 : 0.45;
+  gain.gain.setValueAtTime(peak, when);
+  gain.gain.exponentialRampToValueAtTime(0.0001, when + 0.02);
+
+  noise.connect(filter);
+  filter.connect(gain);
+  gain.connect(destination);
+
+  noise.start(when);
+  noise.stop(when + 0.03);
 }


### PR DESCRIPTION
## Summary
- add audio generators for click, wood, and hi-hat ticks driven by a reusable player
- persist the selected soundKind in the metronome hook and schedule ticks with it
- add a sound selector UI control and wire it into the metronome page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c8acaa187c83248221efc07e596c83